### PR TITLE
chore: use vsi image lookup to automate hardcoded image selection

### DIFF
--- a/examples/advanced/alb.tf
+++ b/examples/advanced/alb.tf
@@ -5,7 +5,7 @@
 resource "ibm_is_instance" "alb_vsi" {
   count   = 2
   name    = "${var.prefix}-alb-vsi-${count.index}"
-  image   = data.ibm_is_image.image.id
+  image   = module.vsi_image_selector.latest_image_id
   profile = "bx2-2x8"
 
   primary_network_attachment {

--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -46,14 +46,22 @@ resource "ibm_is_ssh_key" "public_key" {
   public_key = trimspace(tls_private_key.ssh_key.public_key_openssh)
 }
 
-data "ibm_is_image" "image" {
-  name = "ibm-ubuntu-24-04-3-minimal-amd64-3"
+##############################################################################
+# VSI Image lookup
+##############################################################################
+
+module "vsi_image_selector" {
+  source           = "terraform-ibm-modules/common-utilities/ibm//modules/vsi-image-selector"
+  version          = "1.5.0"
+  architecture     = "amd64"
+  operating_system = "ubuntu"
+  image_status     = "available"
 }
 
 resource "ibm_is_instance" "vsi" {
   count   = 2
   name    = "${var.prefix}-vsi-${count.index}"
-  image   = data.ibm_is_image.image.id
+  image   = module.vsi_image_selector.latest_image_id
   profile = "bx2-2x8"
 
   primary_network_attachment {


### PR DESCRIPTION
### Description

Automates VSI image selection in the advanced example by replacing hardcoded image names with the `vsi-image-selector` module. 

**Changes:**
- Added `vsi-image-selector` module to `examples/advanced/main.tf`
- Configured module with `image_status = "available"` to fetch available images.
- Updated `ibm_is_instance.vsi` and `ibm_is_instance.alb_vsi` to use `module.vsi_image_selector.latest_image_id`
- Removed hardcoded image data source

Fixes #108

### Release required?

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:


```
/run pipeline
```

### Checklist for reviewers

- [x] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.



### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.




